### PR TITLE
Add Xiaomi price parser

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,0 +1,62 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+import os
+import unittest
+from tempfile import TemporaryDirectory
+
+import xiaomi_price_parser as xpp
+
+class TestSelectDateDirs(unittest.TestCase):
+    def test_no_dirs(self):
+        with TemporaryDirectory() as tmp:
+            with self.assertRaises(SystemExit):
+                xpp.select_date_dirs(tmp)
+
+    def test_one_dir(self):
+        with TemporaryDirectory() as tmp:
+            os.mkdir(os.path.join(tmp, '01.01.24'))
+            with self.assertRaises(SystemExit):
+                xpp.select_date_dirs(tmp)
+
+    def test_two_latest(self):
+        with TemporaryDirectory() as tmp:
+            os.mkdir(os.path.join(tmp, '01.01.24'))
+            os.mkdir(os.path.join(tmp, '02.01.24'))
+            os.mkdir(os.path.join(tmp, '03.01.24'))
+            latest = xpp.select_date_dirs(tmp)
+            self.assertEqual(sorted(latest),
+                             sorted([os.path.join(tmp,'02.01.24'), os.path.join(tmp,'03.01.24')]))
+
+class TestParseFileSections(unittest.TestCase):
+    SAMPLE = (
+        'ПРАЙС T87\n'
+        'Model A 🇷🇺 12/256 Black-12000\n'
+        'Model A 🇪🇺 12/256 white -13000\n'
+    )
+
+    def test_parse(self):
+        with TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, 'f.txt')
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(self.SAMPLE)
+            records = xpp.parse_file_sections(path)
+            self.assertEqual(len(records), 2)
+            self.assertEqual(records[0]['memory'], '12/256')
+            self.assertEqual(records[0]['color'], 'Black')
+            self.assertEqual(records[1]['price'], 13000)
+
+class TestGroupPositions(unittest.TestCase):
+    def test_min_price(self):
+        recs = [
+            {'model':'A','region':'','memory':'12/256','color':'Black','price':100,'source':'s1'},
+            {'model':'A','region':'','memory':'12/256','color':'Black','price':90,'source':'s2'},
+            {'model':'A','region':'','memory':'12/256','color':'White','price':110,'source':'s1'},
+        ]
+        grouped = xpp.group_positions(recs)
+        # Should have two groups: Black and White
+        self.assertEqual(len(grouped),2)
+        prices = { (r['color']): r['price'] for r in grouped }
+        self.assertEqual(prices['Black'], 90)
+        self.assertEqual(prices['White'], 110)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/xiaomi_price_parser.py
+++ b/xiaomi_price_parser.py
@@ -1,0 +1,155 @@
+VERSION = '0.9'
+
+import argparse
+import csv
+import json
+import os
+import re
+from datetime import datetime
+
+DATE_PATTERN = re.compile(r"\d{2}\.\d{2}\.\d{2}$")
+REGION_EMOJIS = "🇷🇺🇪🇺🇨🇳🇬🇧"
+
+
+def select_date_dirs(base_dir: str = "."):
+    """Return two latest date directories under base_dir."""
+    dirs = [d for d in os.listdir(base_dir)
+            if os.path.isdir(os.path.join(base_dir, d)) and DATE_PATTERN.match(d)]
+    if len(dirs) < 2:
+        print(f"Ошибка: обнаружено только {len(dirs)} папка(и) с датами, минимум две.")
+        raise SystemExit(1)
+    dirs.sort(key=lambda x: datetime.strptime(x, "%d.%m.%y"))
+    return [os.path.join(base_dir, d) for d in dirs[-2:]]
+
+
+def collect_txt_files(dirs):
+    files = []
+    for d in dirs:
+        for name in os.listdir(d):
+            if name.lower().endswith('.txt'):
+                files.append(os.path.join(d, name))
+    return files
+
+
+LINE_RE = re.compile(
+    rf"^(?P<model>.+?)\s*(?P<region>[{REGION_EMOJIS}])?\s*(?P<memory>\d+(?:/\d+)?(?:gb|GB)?)\s+(?P<color>.+?)\s*-?\s*(?P<price>\d+)\s*$"
+)
+
+
+def parse_file_sections(file_path):
+    records = []
+    try:
+        with open(file_path, encoding='utf-8') as f:
+            lines = f.read().splitlines()
+    except Exception as e:
+        print(f"Ошибка чтения файла {file_path}: {e}")
+        return records
+
+    source = os.path.basename(file_path)
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        if line.startswith('ПРАЙС'):
+            source = line.split(' ', 1)[1].strip() if ' ' in line else line
+            continue
+        m = LINE_RE.match(line)
+        if not m:
+            continue
+        model = m.group('model').strip()
+        region = m.group('region') or ''
+        memory = m.group('memory')
+        memory = memory.lower().replace('gb', '')
+        color = m.group('color').strip().title()
+        price = int(m.group('price'))
+        records.append({
+            'model': model,
+            'region': region,
+            'memory': memory,
+            'color': color,
+            'price': price,
+            'source': source
+        })
+    return records
+
+
+def group_positions(records):
+    grouped = {}
+    for rec in records:
+        key = (rec['model'], rec['region'], rec['memory'], rec['color'])
+        if key not in grouped or rec['price'] < grouped[key]['price']:
+            grouped[key] = rec
+    return list(grouped.values())
+
+
+def save_json(data, path):
+    with open(path, 'w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def save_csv(data, path):
+    header = ['Модель', 'Регион', 'Память', 'Цвет', 'Цена', 'Источник']
+    with open(path, 'w', newline='', encoding='utf-8') as f:
+        writer = csv.writer(f)
+        writer.writerow(header)
+        for rec in data:
+            writer.writerow([
+                rec['model'], rec['region'], rec['memory'],
+                rec['color'], rec['price'], rec['source']
+            ])
+
+
+def compare_prev(curr, prev):
+    curr_keys = { (r['model'], r['region'], r['memory'], r['color']) : r for r in curr }
+    prev_keys = { (r['model'], r['region'], r['memory'], r['color']) : r for r in prev }
+    new = [curr_keys[k] for k in curr_keys.keys() - prev_keys.keys()]
+    removed = [prev_keys[k] for k in prev_keys.keys() - curr_keys.keys()]
+    return new, removed
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--lists', nargs='+', help='Список прайсов')
+    parser.add_argument('--prev', help='Файл предыдущего дня')
+    parser.add_argument('--out_curr', default='curr_data.json')
+    parser.add_argument('--report', default='min_prices_report.csv')
+    args = parser.parse_args()
+
+    if args.lists:
+        txt_files = args.lists
+    else:
+        dirs = select_date_dirs()
+        txt_files = collect_txt_files(dirs)
+    if not txt_files:
+        print('Ошибка: .txt файлы не найдены')
+        raise SystemExit(1)
+
+    all_records = []
+    for path in txt_files:
+        all_records.extend(parse_file_sections(path))
+
+    grouped = group_positions(all_records)
+
+    os.makedirs('Отчеты', exist_ok=True)
+    curr_json = os.path.join('Отчеты', args.out_curr)
+    report_csv = os.path.join('Отчеты', args.report)
+
+    save_json(grouped, curr_json)
+    save_csv(grouped, report_csv)
+
+    if args.prev:
+        try:
+            with open(args.prev, encoding='utf-8') as f:
+                prev_data = json.load(f)
+        except Exception as e:
+            print(f"Ошибка чтения файла {args.prev}: {e}")
+            prev_data = []
+        new, removed = compare_prev(grouped, prev_data)
+        new_csv = os.path.join('Отчеты', 'new_positions_report.csv')
+        removed_csv = os.path.join('Отчеты', 'removed_positions_report.csv')
+        save_csv(new, new_csv)
+        save_csv(removed, removed_csv)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- implement `xiaomi_price_parser.py` to parse price lists and generate reports
- provide unit tests for selecting directories, parsing sections, and grouping records

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849839d07d8832d996e8786a8a826f6